### PR TITLE
Provide ES module content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ typings/
 .next
 
 lib
+lib.es6

--- a/package.json
+++ b/package.json
@@ -18,15 +18,19 @@
     "typescript"
   ],
   "main": "lib/index.js",
+  "module": "lib.es6/index.js",
   "types": "lib/index.d.ts",
   "files": [
-    "lib"
+    "lib",
+    "lib.es6"
   ],
   "scripts": {
     "test": "jest --env=jsdom",
     "test:watch": "jest --watch --env=jsdom",
     "lint": "eslint '*/**/*.{ts,tsx}' --report-unused-disable-directives",
-    "build": "rimraf lib && tsc",
+    "build": "npm run build:cjs && npm run build:es6",
+    "build:cjs": "rimraf lib && tsc",
+    "build:es6": "rimraf lib.es6 && tsc --module es6 --outdir lib.es6",
     "build:watch": "rimraf lib && tsc -w",
     "prepare": "npm run build"
   },


### PR DESCRIPTION
This PR compiles the code into a ES6 module as well, so that it can be used in such environments. In our case specifically: a rollup/webcomponents application.